### PR TITLE
Fix #includes

### DIFF
--- a/src/flintxx/matrix.h
+++ b/src/flintxx/matrix.h
@@ -21,7 +21,7 @@
 #include "ltuple.h"
 #include "traits.h"
 #include "tuple.h"
-#include "permxx.h"
+#include "../permxx.h"
 
 namespace flint {
 FLINT_DEFINE_BINOP(solve)

--- a/src/flintxx_public/fmpqxx.h
+++ b/src/flintxx_public/fmpqxx.h
@@ -15,6 +15,7 @@
 #include <cstdlib>
 
 #include "fmpq.h"
+#include "fmpq_vec.h"
 
 #include "flintxx/expression.h"
 #include "flintxx/flint_classes.h"

--- a/src/flintxx_public/fmpz_factorxx.h
+++ b/src/flintxx_public/fmpz_factorxx.h
@@ -14,6 +14,7 @@
 
 #include "fmpz_factor.h"
 #include "fmpz_vec.h"
+#include "fmpzxx.h"
 
 #include "flintxx/ltuple.h"
 

--- a/src/flintxx_public/fmpz_mod_poly_factorxx.h
+++ b/src/flintxx_public/fmpz_mod_poly_factorxx.h
@@ -14,6 +14,8 @@
 
 
 #include "fmpz_mod_poly.h"
+#include "fmpz_mod_poly_factor.h"
+#include "fmpz_mod_polyxx.h"
 
 namespace flint {
 class fmpz_mod_poly_factorxx

--- a/src/flintxx_public/fmpz_mod_polyxx.h
+++ b/src/flintxx_public/fmpz_mod_polyxx.h
@@ -13,6 +13,7 @@
 #ifndef FMPZ_MOD_POLYXX_H
 #define FMPZ_MOD_POLYXX_H
 
+#include "fmpz_mod.h"
 #include "fmpz_mod_poly.h"
 
 #include "fmpzxx.h"

--- a/src/flintxx_public/fmpz_poly_factorxx.h
+++ b/src/flintxx_public/fmpz_poly_factorxx.h
@@ -14,7 +14,9 @@
 
 
 #include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_polyxx.h"
+#include "nmod_poly_factor.h"
 
 namespace flint {
 class fmpz_poly_factorxx

--- a/src/flintxx_public/fmpz_polyxx.h
+++ b/src/flintxx_public/fmpz_polyxx.h
@@ -943,6 +943,4 @@ int read_pretty(FILE* fi, Fmpz_poly& f, char** x,
 
 #include "nmod_polyxx.h" // modular reconstruction code
 
-#include "fmpz_poly_factorxx.h"
-
 #endif

--- a/src/flintxx_public/nmod_polyxx.h
+++ b/src/flintxx_public/nmod_polyxx.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "nmod_poly.h"
+#include "nmod_poly_factor.h"
 
 #include "fmpzxx.h"
 #include "nmod_vecxx.h"

--- a/src/flintxx_public/nmod_vecxx.h
+++ b/src/flintxx_public/nmod_vecxx.h
@@ -19,6 +19,7 @@
 
 #include <sstream>
 
+#include "nmod.h"
 #include "nmod_vec.h"
 
 // TODO reduce dependencies?


### PR DESCRIPTION
Add some missing includes.

Also remove `#include "fmpz_poly_factorxx.h"` at the end of `fmpz_polyxx.h`. This created a problematic inclusion cycle: If you include `nmod_polyxx.h`, that includes `fmpz_polyxx.h`, which at the end of the file used to include `fmpz_poly_factorxx.h`, which includes (and needs) `nmod_polyxx.h`.