### PR TITLE
Fix compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ syntax. FLINTXX is a set of wrapper C++ classes, together termed flintxx,
 which provide such an object oriented syntax.
 In general, flintxx strives to behave just like the underlying FLINT C, see the documentation for some exceptions.
 
+## Usage
+This is a header-only library.
+It suffices to add `src/` and `src/flintxx_public/` to the include path.
+
 ## Authors
 The author of this C++ wrapper is Tom Bachmann.
 This was originally part of [FLINT](https://github.com/flintlib/flint)

--- a/src/flintxx/evaluation_tools.h
+++ b/src/flintxx/evaluation_tools.h
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-#include "../flint.h" // FLINT_MAX and FLINT_MIN
+#include "flint.h" // FLINT_MAX and FLINT_MIN
 
 #include "expression_traits.h"
 #include "mp.h"

--- a/src/flintxx/examples/fmpz_poly_factor_zassenhaus.cpp
+++ b/src/flintxx/examples/fmpz_poly_factor_zassenhaus.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdio>
 #include "fmpz_polyxx.h"
+#include "fmpz_poly_factorxx.h"
 
 using namespace flint;
 using namespace std;

--- a/src/flintxx/examples/fooxx.cpp
+++ b/src/flintxx/examples/fooxx.cpp
@@ -21,6 +21,7 @@
 #ifndef FOO_H
 #define FOO_H
 #include <stdio.h>
+#include "flint.h"
 
 extern "C" { // usually only #ifdef __cplusplus etc
 typedef slong foo;

--- a/src/flintxx/examples/radix.cpp
+++ b/src/flintxx/examples/radix.cpp
@@ -32,8 +32,9 @@ int main(void)
 
     fmpzxx m(17);
     m = m.pow(26u);
+    fmpz_modxx_ctx ctx(m);
 
-    fmpz_mod_polyxx A(m), B(m);
+    fmpz_mod_polyxx A(ctx), B(ctx);
 
     A.set_coeff(3, 5);
     A.set_coeff(4, 4);
@@ -51,9 +52,9 @@ int main(void)
 
     fmpz_mod_polyxx r(A.pow(3u) * fmpzxx(4) + B.pow(2u) * fmpzxx(27));
 
-    fmpz_mod_poly_vecxx b(N + 1, m);
+    fmpz_mod_poly_vecxx b(N + 1, ctx);
 
-    fmpz_mod_polyxx t = fmpz_mod_polyxx::randtest(m, state, n + 1);
+    fmpz_mod_polyxx t = fmpz_mod_polyxx::randtest(ctx, state, n + 1);
 
     flint_printf("Radix conversion\n");
     flint_printf("----------------\n");

--- a/src/flintxx/flint_classes.h
+++ b/src/flintxx/flint_classes.h
@@ -13,7 +13,7 @@
 // Contrary to other parts of this library, they are tailored very
 // specifically towards FLINT.
 
-#include "../flint.h"
+#include "flint.h"
 #include "mp.h"
 #include "expression.h"
 #include "expression_traits.h"

--- a/src/flintxx/frandxx.h
+++ b/src/flintxx/frandxx.h
@@ -12,7 +12,7 @@
 #ifndef CXX_FRANDXX_H
 #define CXX_FRANDXX_H
 
-#include "../flint.h"
+#include "flint.h"
 
 // This class contains a first-class wrapper of flint_rand_t.
 // Note that frandxx is not copyable.
@@ -27,8 +27,8 @@ private:
     frandxx(const frandxx&);
 
 public:
-    frandxx() {flint_randinit(inner);}
-    ~frandxx() {flint_randclear(inner);}
+    frandxx() {flint_rand_init(inner);}
+    ~frandxx() {flint_rand_clear(inner);}
 
     flint_rand_t& _data() {return inner;}
     const flint_rand_t& _data() const {return inner;}

--- a/src/flintxx/matrix.h
+++ b/src/flintxx/matrix.h
@@ -21,7 +21,7 @@
 #include "ltuple.h"
 #include "traits.h"
 #include "tuple.h"
-#include "../permxx.h"
+#include "permxx.h"
 
 namespace flint {
 FLINT_DEFINE_BINOP(solve)

--- a/src/flintxx/test/t-arithxx.cpp
+++ b/src/flintxx/test/t-arithxx.cpp
@@ -26,15 +26,6 @@ test_stirling()
     fmpz_vecxx v1(func##_vec(n, k).evaluate() /* test temporary alloc */); \
     for(slong i = 0;i < v1.size();++i) \
         tassert(v1[i] == func(n, i)); \
-    tassert(func##_vec_next(func##_vec(n, k), n+1).size() == k); \
-    fmpz_vecxx v2(func##_vec_next(v1, n+1)); \
-    for(slong i = 0;i < v2.size();++i) \
-        tassert(v2[i] == func(n+1, i)); \
-    fmpz_vecxx v3(func##_vec(n, n+1)); \
-    fmpz_vecxx v4(func##_vec_next(v3, n+1)); \
-    tassert(v4.size() == n+2 && v3.size() == n+1); \
-    for(slong i = 0;i < v4.size();++i) \
-        tassert(v4[i] == func(n+1, i)); \
     tassert(matfunc(n, k).rows() == n && matfunc(n, k).cols() == k); \
     fmpz_matxx M(matfunc(n, k).evaluate() /* test temporaries */); \
     for(slong i = 0;i < M.rows();++i) \

--- a/src/flintxx/test/t-fmpz_polyxx.cpp
+++ b/src/flintxx/test/t-fmpz_polyxx.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "fmpz_polyxx.h"
+#include "fmpz_poly_factorxx.h"
 #include "nmod_polyxx.h"
 
 #include "flintxx/test/helpers.h"

--- a/src/flintxx_public/arithxx.h
+++ b/src/flintxx_public/arithxx.h
@@ -81,9 +81,6 @@ ARITHXX_DEFINE_BINOP(stirling_number_2, fmpzxx, at::slong, at::slong)
 ARITHXX_DEFINE_BINOP(stirling_number_1u_vec, fmpz_vecxx, at::slong, at::slong)
 ARITHXX_DEFINE_BINOP(stirling_number_1_vec, fmpz_vecxx, at::slong, at::slong)
 ARITHXX_DEFINE_BINOP(stirling_number_2_vec, fmpz_vecxx, at::slong, at::slong)
-FLINT_DEFINE_BINOP(stirling_number_1u_vec_next)
-FLINT_DEFINE_BINOP(stirling_number_1_vec_next)
-FLINT_DEFINE_BINOP(stirling_number_2_vec_next)
 FLINT_DEFINE_BINOP(stirling_matrix_1u)
 FLINT_DEFINE_BINOP(stirling_matrix_1)
 FLINT_DEFINE_BINOP(stirling_matrix_2)
@@ -99,23 +96,6 @@ template<> struct outsize<operations::stirling_number_1_vec_op>
     : outsize<operations::stirling_number_1u_vec_op> { };
 template<> struct outsize<operations::stirling_number_2_vec_op>
     : outsize<operations::stirling_number_1u_vec_op> { };
-
-template<>
-struct outsize<operations::stirling_number_1u_vec_next_op>
-{
-    template<class Expr>
-    static unsigned get(const Expr& e)
-    {
-        slong r = e._data().first().size();
-        if(r == e._data().second())
-            return r + 1;
-        return r;
-    }
-};
-template<> struct outsize<operations::stirling_number_1_vec_next_op>
-    : outsize<operations::stirling_number_1u_vec_next_op> { };
-template<> struct outsize<operations::stirling_number_2_vec_next_op>
-    : outsize<operations::stirling_number_1u_vec_next_op> { };
 } // vectors
 
 namespace matrices {
@@ -134,19 +114,6 @@ template<> struct outsize<operations::stirling_matrix_2_op>
 } // matrices
 
 namespace rules {
-FLINT_DEFINE_BINARY_EXPR_COND2(stirling_number_1u_vec_next_op, fmpz_vecxx,
-        FMPZ_VECXX_COND_S, at::slong,
-        arith_stirling_number_1u_vec_next(to._array(), e1._array(), e2,
-            e1.size() + (e1.size() == e2)))
-FLINT_DEFINE_BINARY_EXPR_COND2(stirling_number_1_vec_next_op, fmpz_vecxx,
-        FMPZ_VECXX_COND_S, at::slong,
-        arith_stirling_number_1_vec_next(to._array(), e1._array(), e2,
-            e1.size() + (e1.size() == e2)))
-FLINT_DEFINE_BINARY_EXPR_COND2(stirling_number_2_vec_next_op, fmpz_vecxx,
-        FMPZ_VECXX_COND_S, at::slong,
-        arith_stirling_number_2_vec_next(to._array(), e1._array(), e2,
-            e1.size() + (e1.size() == e2)))
-
 FLINT_DEFINE_BINARY_EXPR_COND2(stirling_matrix_1u_op, fmpz_matxx,
         at::slong, at::slong, arith_stirling_matrix_1u(to._mat()))
 FLINT_DEFINE_BINARY_EXPR_COND2(stirling_matrix_1_op, fmpz_matxx,

--- a/src/flintxx_public/fmpz_mod_polyxx.h
+++ b/src/flintxx_public/fmpz_mod_polyxx.h
@@ -628,27 +628,11 @@ FLINT_DEFINE_BINARY_EXPR_COND2(divrem_basecase_op, rdetail::fmpz_mod_polyxx_pair
         to.template get<0>()._poly(), to.template get<1>()._poly(),
         e1._poly(), e2._poly(), e1._ctx()))
 
-FLINT_DEFINE_BINARY_EXPR_COND2(divrem_divconquer_op, rdetail::fmpz_mod_polyxx_pair,
-    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_divrem_divconquer(
-        to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly(), e1._ctx()))
-
-FLINT_DEFINE_BINARY_EXPR_COND2(divrem_op, rdetail::fmpz_mod_polyxx_pair,
-    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_divrem_divconquer(
-        to.template get<0>()._poly(), to.template get<1>()._poly(),
-        e1._poly(), e2._poly(), e1._ctx()))
-
 FLINT_DEFINE_BINARY_EXPR_COND2(divrem_f_op, rdetail::fmpz_mod_poly_divrem_f_rt,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_divrem_f(
         to.template get<0>()._fmpz(), to.template get<1>()._poly(),
         to.template get<2>()._poly(), e1._poly(), e2._poly(), e1._ctx()))
-
-FLINT_DEFINE_BINARY_EXPR_COND2(div_basecase_op, fmpz_mod_polyxx,
-    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_div_basecase(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 FLINT_DEFINE_BINARY_EXPR_COND2(rem_basecase_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
@@ -661,10 +645,6 @@ FLINT_DEFINE_BINARY_EXPR_COND2(inv_series_newton_op, fmpz_mod_polyxx,
 FLINT_DEFINE_BINARY_EXPR_COND2(gcd_op, fmpz_mod_polyxx,
     FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
     fmpz_mod_poly_gcd(to._poly(), e1._poly(), e2._poly(), to._ctx()))
-
-FLINT_DEFINE_BINARY_EXPR_COND2(gcd_euclidean_op, fmpz_mod_polyxx,
-    FMPZ_MOD_POLYXX_COND_S, FMPZ_MOD_POLYXX_COND_S,
-    fmpz_mod_poly_gcd_euclidean(to._poly(), e1._poly(), e2._poly(), to._ctx()))
 
 namespace rdetail {
 typedef make_ltuple<mp::make_tuple<

--- a/src/flintxx_public/fmpzxx.h
+++ b/src/flintxx_public/fmpzxx.h
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <vector>
+#include "gmp.h"
 
 #include "flintxx/evaluation_tools.h"
 #include "flintxx/expression.h"

--- a/src/flintxx_public/nmod_polyxx.h
+++ b/src/flintxx_public/nmod_polyxx.h
@@ -757,10 +757,6 @@ NMOD_POLYXX_DEFINE_SERIES_F(sinh)
 NMOD_POLYXX_DEFINE_SERIES_F(cosh)
 NMOD_POLYXX_DEFINE_SERIES_F(tanh)
 
-FLINT_DEFINE_BINARY_EXPR_COND2(exp_series_basecase_op, nmod_polyxx,
-        NMOD_POLYXX_COND_S, traits::fits_into_slong,
-        nmod_poly_exp_series_basecase(to._poly(), e1._poly(), e2))
-
 FLINT_DEFINE_THREEARY_EXPR_COND3(log_series_monomial_op, nmod_polyxx,
         NMODXX_COND_S, traits::is_unsigned_integer, traits::fits_into_slong,
         nmod_poly_log_series_monomial_ui(to._poly(), e1._limb(), e2, e3))

--- a/src/flintxx_public/permxx.h
+++ b/src/flintxx_public/permxx.h
@@ -49,7 +49,7 @@ public:
     static permxx randtest(slong n, frandxx& state)
         {permxx res(n);res.set_randtest(state);return res;}
 
-    void set_one() {_perm_set_one(_data(), size());}
+    void set_one() {_perm_one(_data(), size());}
     int set_randtest(frandxx& state)
         {return _perm_randtest(_data(), size(), state._data());}
 
@@ -93,7 +93,7 @@ template<class T> struct is_permxx : mp::equal_types<T, permxx> { };
 
 inline int print(const permxx& p)
 {
-    return _perm_print(p._data(), p.size());
+    return flint_printf("%{slong*}", p._data(), p.size());
 }
 } // flint
 


### PR DESCRIPTION
After this change, all examples compile with latest flint on my machine.

Some (but not all) tests compile on my machine.

Do check if the `Usage` is correct.

Closes https://github.com/flintlib/flintxx/issues/8